### PR TITLE
Add linting to pipeline

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,10 +19,12 @@ jobs:
       run: dotnet restore $SOURCE_DIRECTORY
     - name: Build
       run: dotnet build $SOURCE_DIRECTORY
-    - name: Linting
-      run: |
-        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} HEAD)
-        dotnet format $SOURCE_DIRECTORY --verify-no-changes --no-restore --include $FILES_CHANGED --severity error -v diagnostic --report ./testresults/
+    - name: Linting files
+      run: git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} HEAD
+    # - name: Linting
+    #   run: |
+    #     FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} HEAD)
+    #     dotnet format $SOURCE_DIRECTORY --verify-no-changes --no-restore --include $FILES_CHANGED --severity error -v diagnostic --report ./testresults/
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -24,7 +24,9 @@ jobs:
         GITHUB_CONTEXT: ${{ toJSON(github) }}
       run: echo "$GITHUB_CONTEXT"
     - name: Linting files
-      run: git diff-tree --no-commit-id --name-only -r ${{ github.event.workflow_run.head_sha }} HEAD
+      run: |
+        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD)
+        echo $FILES_CHANGED
     # - name: Linting
     #   run: |
     #     FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} HEAD)

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,8 +19,12 @@ jobs:
       run: dotnet restore $SOURCE_DIRECTORY
     - name: Build
       run: dotnet build $SOURCE_DIRECTORY
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJSON(github) }}
+      run: echo "$GITHUB_CONTEXT"
     - name: Linting files
-      run: git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.head.sha }} HEAD
+      run: git diff-tree --no-commit-id --name-only -r ${{ github.event.workflow_run.head_sha }} HEAD
     # - name: Linting
     #   run: |
     #     FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} HEAD)

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
     - name: Setup dotnet
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 1
+        fetch-depth: 2
     - name: Setup dotnet
       uses: actions/setup-dotnet@v3
       with:
@@ -23,7 +23,7 @@ jobs:
       run: dotnet build $SOURCE_DIRECTORY
     - name: Linting files
       run: |
-        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} HEAD)
         echo $FILES_CHANGED
     # - name: Linting
     #   run: |

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,13 +19,9 @@ jobs:
       run: dotnet restore $SOURCE_DIRECTORY
     - name: Build
       run: dotnet build $SOURCE_DIRECTORY
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJSON(github) }}
-      run: echo "$GITHUB_CONTEXT"
     - name: Linting files
       run: |
-        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD)
+        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
         echo $FILES_CHANGED
     # - name: Linting
     #   run: |

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Build
       run: dotnet build $SOURCE_DIRECTORY
     - name: Linting files
-      run: git diff-tree --no-commit-id --name-only -r HEAD
+      run: git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.head.sha }} HEAD
     # - name: Linting
     #   run: |
     #     FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} HEAD)

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,6 +19,10 @@ jobs:
       run: dotnet restore $SOURCE_DIRECTORY
     - name: Build
       run: dotnet build $SOURCE_DIRECTORY
+    - name: Linting
+      run: |
+        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} HEAD)
+        dotnet format $SOURCE_DIRECTORY --verify-no-changes --no-restore --include $FILES_CHANGED --severity error -v diagnostic --report ./testresults/
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -21,14 +21,10 @@ jobs:
       run: dotnet restore $SOURCE_DIRECTORY
     - name: Build
       run: dotnet build $SOURCE_DIRECTORY
-    - name: Linting files
+    - name: Linting
       run: |
         FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} HEAD)
-        echo $FILES_CHANGED
-    # - name: Linting
-    #   run: |
-    #     FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} HEAD)
-    #     dotnet format $SOURCE_DIRECTORY --verify-no-changes --no-restore --include $FILES_CHANGED --severity error -v diagnostic --report ./testresults/
+        dotnet format $SOURCE_DIRECTORY --verify-no-changes --no-restore --include $FILES_CHANGED --severity error -v diagnostic --report ./testresults/
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Build
       run: dotnet build $SOURCE_DIRECTORY
     - name: Linting files
-      run: git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} HEAD
+      run: git diff-tree --no-commit-id --name-only -r HEAD
     # - name: Linting
     #   run: |
     #     FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }} HEAD)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-#disabled to due https://github.com/dotnet/format/issues/1546
-#dotnet husky run -v --group "pre-commit"
+dotnet husky run -v --group "pre-commit"


### PR DESCRIPTION
- Set `fetch-depth` to `2`
- Use `dotnet format` to validate files conform to linting rules